### PR TITLE
Add NiFi cluster docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# temp
+# NiFi Cluster Docker Compose
+
+This repository provides a simple Docker Compose configuration for running a three node Apache NiFi cluster on a local Windows machine. Each NiFi node joins the same cluster using ZooKeeper.
+
+## Usage
+
+1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) for Windows.
+2. From this directory run:
+
+```bash
+docker compose up -d
+```
+
+The NiFi UI for each node will be available on the following ports:
+
+- Node 1: <http://localhost:8081>
+- Node 2: <http://localhost:8083>
+- Node 3: <http://localhost:8085>
+
+## HTTP vs HTTPS
+
+The provided configuration exposes NiFi over HTTP for simplicity. For development environments this may be sufficient. For production or any environment requiring encryption or authentication, configure HTTPS by supplying TLS certificates and adjusting the `NIFI_WEB_HTTPS_PORT` and related properties. Refer to the [Apache NiFi documentation](https://nifi.apache.org/docs.html) for details on securing your cluster.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+version: '3'
+services:
+  zookeeper:
+    image: bitnami/zookeeper:3.8
+    container_name: zookeeper
+    environment:
+      ALLOW_ANONYMOUS_LOGIN: "yes"
+    ports:
+      - "2181:2181"
+
+  nifi-node1:
+    image: apache/nifi:1.24.0
+    hostname: nifi-node1
+    container_name: nifi-node1
+    environment:
+      - NIFI_WEB_HTTP_PORT=8080
+      - NIFI_CLUSTER_IS_NODE=true
+      - NIFI_CLUSTER_NODE_PROTOCOL_PORT=8082
+      - NIFI_ZK_CONNECT_STRING=zookeeper:2181
+      - SINGLE_USER_CREDENTIALS_USERNAME=admin
+      - SINGLE_USER_CREDENTIALS_PASSWORD=admin123
+    ports:
+      - "8081:8080"
+      - "8082:8082"
+    depends_on:
+      - zookeeper
+
+  nifi-node2:
+    image: apache/nifi:1.24.0
+    hostname: nifi-node2
+    container_name: nifi-node2
+    environment:
+      - NIFI_WEB_HTTP_PORT=8080
+      - NIFI_CLUSTER_IS_NODE=true
+      - NIFI_CLUSTER_NODE_PROTOCOL_PORT=8082
+      - NIFI_ZK_CONNECT_STRING=zookeeper:2181
+      - SINGLE_USER_CREDENTIALS_USERNAME=admin
+      - SINGLE_USER_CREDENTIALS_PASSWORD=admin123
+    ports:
+      - "8083:8080"
+      - "8084:8082"
+    depends_on:
+      - zookeeper
+
+  nifi-node3:
+    image: apache/nifi:1.24.0
+    hostname: nifi-node3
+    container_name: nifi-node3
+    environment:
+      - NIFI_WEB_HTTP_PORT=8080
+      - NIFI_CLUSTER_IS_NODE=true
+      - NIFI_CLUSTER_NODE_PROTOCOL_PORT=8082
+      - NIFI_ZK_CONNECT_STRING=zookeeper:2181
+      - SINGLE_USER_CREDENTIALS_USERNAME=admin
+      - SINGLE_USER_CREDENTIALS_PASSWORD=admin123
+    ports:
+      - "8085:8080"
+      - "8086:8082"
+    depends_on:
+      - zookeeper
+
+networks:
+  default:
+    name: nifi-net


### PR DESCRIPTION
## Summary
- add a Docker Compose file for a 3-node NiFi cluster with ZooKeeper
- document how to run the cluster and discuss HTTP vs HTTPS

## Testing
- `docker compose version` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684255ed842c83329941ffc14c0d3841